### PR TITLE
Remove 'thoroughly documented' from list of advantages

### DIFF
--- a/source/getting-started/index.html.haml
+++ b/source/getting-started/index.html.haml
@@ -38,4 +38,3 @@ title: Getting Started
         %li It exposes the full power of Redis rather than using it to serialize JSON.
         %li It's easy to develop and test plugins for with the provied <a href="https://github.com/rspec/rspec">RSpec</a> extras. Lita strongly encourages thorough testing of plugins.
         %li It uses the Ruby ecosystem's standard tools (RubyGems and Bundler) for plugin installation and loading.
-        %li It's thoroughly documented.


### PR DESCRIPTION
This was probably true when lita was first written, but last year I did a pretty extensive rewrite of the hubot documentation over in in https://github.com/github/hubot/tree/master/docs .
